### PR TITLE
Added 2000 channel task Limit

### DIFF
--- a/components/liveTv/LoadChannelsTask.xml
+++ b/components/liveTv/LoadChannelsTask.xml
@@ -2,7 +2,7 @@
 
 <component name="LoadChannelsTask" extends="Task">
   <interface>
-    <field id="limit" type="integer" value="500" />
+    <field id="limit" type="integer" value="2000" />
     <field id="startIndex" type="integer" value="0" />
     
     <!-- Total records available from server-->

--- a/components/liveTv/LoadChannelsTask.xml
+++ b/components/liveTv/LoadChannelsTask.xml
@@ -2,7 +2,7 @@
 
 <component name="LoadChannelsTask" extends="Task">
   <interface>
-    <field id="limit" type="integer" value="2000" />
+    <field id="limit" type="integer" value="" />
     <field id="startIndex" type="integer" value="0" />
     
     <!-- Total records available from server-->


### PR DESCRIPTION
Updated the load channels task to have a limit of 2000
From = <field id="limit" type="integer" value="500" />
to =  <field id="limit" type="integer" value="2000" />


**Changes**
Allow more channels to be loaded. Did see any visual preformance issues 


