### PR TITLE
Update schedule.brs

### DIFF
--- a/components/liveTv/schedule.brs
+++ b/components/liveTv/schedule.brs
@@ -66,10 +66,10 @@ sub onScheduleLoaded()
 
         channel = m.scheduleGrid.content.GetChild(m.channelIndex[item.ChannelId])
         
-        if channel.PosterUrl <> "" 
+        if channel.PosterUrl <> "" then 
             item.channelLogoUri = channel.PosterUrl
         end if
-        if channel.Title <> "" 
+        if channel.Title <> "" then 
             item.channelName = channel.Title
         end if
 
@@ -88,14 +88,14 @@ sub onProgramFocused()
     m.detailsPane.channel = channel
 
     ' Exit if Channels not yet loaded
-    if channel.getChildCount() = 0
+    if channel.getChildCount() = 0 then
         m.detailsPane.programDetails = invalid
         return
     end if
 
     prog = channel.GetChild(m.scheduleGrid.programFocusedDetails.focusIndex)
 
-    if prog <> invalid and prog.fullyLoaded = false
+    if prog <> invalid and prog.fullyLoaded = false then
         m.LoadProgramDetailsTask.programId = prog.Id
         m.LoadProgramDetailsTask.channelIndex = m.scheduleGrid.programFocusedDetails.focusChannelIndex
         m.LoadProgramDetailsTask.programIndex = m.scheduleGrid.programFocusedDetails.focusIndex
@@ -111,7 +111,7 @@ sub onProgramDetailsLoaded()
     channel = m.scheduleGrid.content.GetChild(m.LoadProgramDetailsTask.programDetails.channelIndex)
 
     ' If TV Show does not have its own image, use the channel logo
-    if m.LoadProgramDetailsTask.programDetails.PosterUrl = invalid or m.LoadProgramDetailsTask.programDetails.PosterUrl = ""
+    if m.LoadProgramDetailsTask.programDetails.PosterUrl = invalid or m.LoadProgramDetailsTask.programDetails.PosterUrl = "" then
         m.LoadProgramDetailsTask.programDetails.PosterUrl = channel.PosterUrl
     end if
 
@@ -122,7 +122,7 @@ end sub
 
 sub onProgramSelected()
     ' If there is no program data - view the channel
-    if m.detailsPane.programDetails = invalid
+    if m.detailsPane.programDetails = invalid then
         m.top.watchChannel = m.scheduleGrid.content.GetChild(m.scheduleGrid.programFocusedDetails.focusChannelIndex)
         return
     end if
@@ -138,7 +138,7 @@ sub focusProgramDetails(setFocused)
     if h < 400 then h = 400
     h = h + 160 + 80
 
-    if setFocused = true
+    if setFocused = true then
         m.gridMoveAnimationPosition.keyValue = [ [0,600], [0, h] ]
         m.detailsPane.setFocus(true)
         m.detailsPane.hasFocus = true
@@ -168,10 +168,10 @@ end sub
 sub onGridScrolled()
 
     ' If we're within 12 hours of end of grid, load next 24hrs of data
-    if m.scheduleGrid.leftEdgeTargetTime + (12 * 60 * 60) > m.gridEndDate.AsSeconds()
+    if m.scheduleGrid.leftEdgeTargetTime + (12 * 60 * 60) > m.gridEndDate.AsSeconds() then
 
         ' Ensure the task is not already (still) running, 
-        if  m.LoadScheduleTask.state <> "run" 
+        if  m.LoadScheduleTask.state <> "run" then 
             m.LoadScheduleTask.startTime = m.gridEndDate.ToISOString()
             m.gridEndDate.FromSeconds(m.gridEndDate.AsSeconds() + (24 * 60 * 60))
             m.LoadScheduleTask.endTime = m.gridEndDate.ToISOString()
@@ -183,7 +183,7 @@ end sub
 function onKeyEvent(key as string, press as boolean) as boolean
     if not press then return false
 
-    if key = "back" and m.detailsPane.isInFocusChain()
+    if key = "back" or key = "down" and m.detailsPane.isInFocusChain() then
         focusProgramDetails(false)
         return true
     end if


### PR DESCRIPTION
Added Key press down to return to TV giude. This seems a more natural way to move from the top details "View channel button" back to the guide.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->

**Changes**
added the key = "down" to move from the top section to the bottom 

**Issues**
none, just a more natural flow between sections on screen
