### PR TITLE
change extras slider height

### DIFF
--- a/components/PersonDetails.brs
+++ b/components/PersonDetails.brs
@@ -5,9 +5,9 @@ sub init()
     m.btnGrp.observeField("escape", "onButtonGroupEscaped")
     m.favBtn = m.top.findNode("favorite-button")
     m.extrasGrp = m.top.findNode("extrasGrp")
-    m.top.findNode("VertSlider").keyValue = "[[30, 998], [30, 789], [30, 580], [30,371 ], [30, 162]]"
+    'm.top.findNode("VertSlider").keyValue = "[[30, 998], [30, 789], [30, 580], [30,371 ], [30, 162]]"
     m.extrasGrp.opacity = 0
-    m.extrasGrp.translation = "[30, 998]"
+    'm.extrasGrp.translation = "[30, 998]"
     m.dscr.observeField("isTextEllipsized", "onEllipsisChanged")
     createDialogPallete()
     m.top.optionsAvailable = false

--- a/components/extras/ExtrasRowList.brs
+++ b/components/extras/ExtrasRowList.brs
@@ -51,8 +51,6 @@ sub loadParts(data as object, playback = false)
         m.LoadSeriesTask.observeField("content", "onSeriesLoaded")
         m.LoadSeriesTask.control = "RUN"
     end if
-    m.LoadAdditionalPartsTask.itemId = m.top.parentId
-    m.LoadAdditionalPartsTask.control = "RUN"
 end sub
 
 sub loadPersonVideos(personId)
@@ -70,9 +68,8 @@ sub onAdditionalPartsLoaded()
         row = buildRow("Additional Parts", parts, 464)
         addRowSize([464, 291])
         m.top.content.appendChild(row)
+        print "THIS ROW SIZE"
         m.top.rowItemSize = [[464, 291]]
-    else
-        m.top.rowItemSize = [[234, 396]]
     end if
     m.top.translation = "[75,10]"
 
@@ -80,6 +77,7 @@ sub onAdditionalPartsLoaded()
 end sub
 
 sub onPeopleLoaded()
+    m.top.rowItemSize = [[234, 396]]
     people = m.LoadPeopleTask.content
     m.loadPeopleTask.unobserveField("content")
     if people <> invalid and people.count() > 0

--- a/components/extras/ExtrasRowList.brs
+++ b/components/extras/ExtrasRowList.brs
@@ -31,9 +31,26 @@ sub updateSize()
     m.top.rowItemSpacing = [36, 36]
 end sub
 
-sub loadParts(data as object)
+sub loadParts(data as object, playback = false)
+    m.top.content = CreateObject("roSGNode", "ContentNode") ' The row Node
     m.top.parentId = data.id
     m.people = data.People
+    m.LoadPeopleTask.peopleList = m.people
+    m.LoadPeopleTask.control = "RUN"
+    if not playback
+        m.LoadAdditionalPartsTask.itemId = m.top.parentId
+        m.LoadAdditionalPartsTask.control = "RUN"
+        m.LikeThisTask.itemId = m.top.parentId
+        m.LikeThisTask.control = "RUN"
+        m.SpecialFeaturesTask.itemId = m.top.parentId
+        m.SpecialFeaturesTask.control = "RUN"
+        m.LoadShowsTask.itemId = m.personId
+        m.LoadShowsTask.observeField("content", "onShowsLoaded")
+        m.LoadShowsTask.control = "RUN"
+        m.LoadSeriesTask.itemId = m.personId
+        m.LoadSeriesTask.observeField("content", "onSeriesLoaded")
+        m.LoadSeriesTask.control = "RUN"
+    end if
     m.LoadAdditionalPartsTask.itemId = m.top.parentId
     m.LoadAdditionalPartsTask.control = "RUN"
 end sub
@@ -49,8 +66,6 @@ sub onAdditionalPartsLoaded()
     parts = m.LoadAdditionalPartsTask.content
     m.LoadAdditionalPartsTask.unobserveField("content")
 
-    data = CreateObject("roSGNode", "ContentNode") ' The row Node
-    m.top.content = data
     if parts <> invalid and parts.count() > 0
         row = buildRow("Additional Parts", parts, 464)
         addRowSize([464, 291])
@@ -61,9 +76,7 @@ sub onAdditionalPartsLoaded()
     end if
     m.top.translation = "[75,10]"
 
-    ' Load Cast and Crew and everything else...
-    m.LoadPeopleTask.peopleList = m.people
-    m.LoadPeopleTask.control = "RUN"
+
 end sub
 
 sub onPeopleLoaded()
@@ -82,8 +95,6 @@ sub onPeopleLoaded()
             row.appendChild(person)
         end for
     end if
-    m.LikeThisTask.itemId = m.top.parentId
-    m.LikeThisTask.control = "RUN"
 end sub
 
 sub onLikeThisLoaded()
@@ -107,9 +118,6 @@ sub onLikeThisLoaded()
         end for
         addRowSize([234, 396])
     end if
-    ' Special Features next...
-    m.SpecialFeaturesTask.itemId = m.top.parentId
-    m.SpecialFeaturesTask.control = "RUN"
 end sub
 
 function onSpecialFeaturesLoaded()
@@ -150,9 +158,6 @@ sub onMoviesLoaded()
         m.top.rowItemSize = [[234, 396]]
     end if
     m.top.content = rlContent
-    m.LoadShowsTask.itemId = m.personId
-    m.LoadShowsTask.observeField("content", "onShowsLoaded")
-    m.LoadShowsTask.control = "RUN"
 end sub
 
 sub onShowsLoaded()
@@ -163,9 +168,6 @@ sub onShowsLoaded()
         addRowSize([502, 396])
         m.top.content.appendChild(row)
     end if
-    m.LoadSeriesTask.itemId = m.personId
-    m.LoadSeriesTask.observeField("content", "onSeriesLoaded")
-    m.LoadSeriesTask.control = "RUN"
 end sub
 
 sub onSeriesLoaded()

--- a/components/extras/ExtrasSlider.xml
+++ b/components/extras/ExtrasSlider.xml
@@ -3,7 +3,7 @@
   <children>
     <Rectangle id="extrasGrp" color="#0A0010" opacity="0.3" width="1860" height="900" translation="[30, 1014]" >
       <ExtrasRowList id="extrasGrid"
-        itemSpacing="[ 60, 132]"
+        itemSpacing="[ 60, 100]"
         rowLabelOffset="[ [9, 24] ]"
         numRows="2"
         showRowLabel="true"
@@ -15,7 +15,7 @@
         <Vector2DFieldInterpolator
             id="VertSlider"
             key="[0.0, 0.25, 0.50, 75.0, 1.0]"
-            keyValue="[[30, 1014], [30, 804], [30, 588], [30,375 ], [30, 162]]"
+            keyValue="[[30, 1014], [30, 890], [30, 766], [30, 642], [30, 518]]"
             fieldToInterp="extrasGrp.translation" />
         <FloatFieldInterpolator
             id="extrasFader"

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -537,7 +537,7 @@ function CreateVideoPlayerGroup(video_id, mediaSourceId = invalid, audio_stream_
 
     extras = video.findNode("extrasGrid")
     extras.observeField("selectedItem", m.port)
-    extras.callFunc("loadParts", ItemMetaData(video_id).json)
+    extras.callFunc("loadParts", ItemMetaData(video_id).json, true)
 
     return video
 end function


### PR DESCRIPTION
modify height of extras slider app-wide to be more conventional and elliminate dead space on bottom row.
add flags to ExtrasRowList to modify the loading process (we can't simply check the global playstate because this happens before playback). I can't figure out why LoadAdditionalPartsTask must be called in order to get the posters to display correctly, but that should get fixed. has not been tested on items that have "additional parts"