### PR TITLE
simpler spinner code

### DIFF
--- a/components/data/SceneManager.brs
+++ b/components/data/SceneManager.brs
@@ -246,14 +246,6 @@ sub userMessage(title as string, message as string)
 end sub
 
 '
-' Display Dialog to show user app is fetching server data
-sub progressDialog(title as string)
-    dialog = createObject("roSGNode", "ProgressDialog")
-    dialog.title = title
-    m.scene.dialog = dialog
-end sub
-
-'
 ' Close currently displayed dialog
 sub dismiss_dialog()
     print "Button Pressed"

--- a/components/data/SceneManager.xml
+++ b/components/data/SceneManager.xml
@@ -9,8 +9,6 @@
     <function name="clearPreviousScene" />
     <function name="resetTime" />
     <function name="userMessage" />
-    <function name="progressDialog" />
-    <function name="dismiss_dialog" />
     <field id="currentUser" type="string" onChange="updateUser" />
   </interface>
   <script type="text/brightscript" uri="SceneManager.brs" />

--- a/components/movies/MovieDetails.brs
+++ b/components/movies/MovieDetails.brs
@@ -19,6 +19,8 @@ sub init()
     m.buttonGrp.setFocus(true)
     m.top.lastFocus = m.buttonGrp
 
+    m.spinner = m.top.findNode("spinner")
+
     m.trailerButton = m.top.findNode("trailer-button")
     m.trailerButton.text = tr("Play Trailer")
 

--- a/components/movies/MovieDetails.brs
+++ b/components/movies/MovieDetails.brs
@@ -19,13 +19,10 @@ sub init()
     m.buttonGrp.setFocus(true)
     m.top.lastFocus = m.buttonGrp
 
-    m.spinner = m.top.findNode("spinner")
-
     m.trailerButton = m.top.findNode("trailer-button")
     m.trailerButton.text = tr("Play Trailer")
 
     m.top.observeField("itemContent", "itemContentChanged")
-    m.top.findNode("communityRatingGroup").visible = false
 end sub
 
 sub OnScreenShown()

--- a/components/movies/MovieDetails.xml
+++ b/components/movies/MovieDetails.xml
@@ -8,7 +8,7 @@
           <Label id="releaseYear" />
           <Label id="runtime" />
           <Label id="officialRating" />
-          <LayoutGroup id="communityRatingGroup" layoutDirection="horiz" itemSpacings="[-5]">
+          <LayoutGroup id="communityRatingGroup" layoutDirection="horiz" itemSpacings="[-5]" visible="false">
             <Poster id="star" uri="pkg:/images/sharp_star_white_18dp.png" height="32" width="32" blendColor="#cb272a" visible="false"/>
             <Label id="communityRating" />
           </LayoutGroup>

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -1022,16 +1022,6 @@
             <translation>If enabled, the star and community rating for episodes of a TV show will be removed. This is to prevent spoilers of an upcoming good/bad episode.</translation>
         </message>
         <message>
-            <source>Loading Episode Options</source>
-            <translation>Loading Episode Options</translation>
-        </message>
-        <message>
-            <source>Loading Video Options</source>
-            <translation>Loading Video Options</translation>
-        </message>
-        <message>
-            <source>Loading Movie Options</source>
-            <translation>Loading Movie Options</translation>
             <source>Libraries</source>
             <translation>Libraries</translation>
         </message>

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -167,7 +167,6 @@ sub Main (args as dynamic) as void
             else if selectedItem.type = "Episode"
                 ' play episode
                 ' todo: create an episode page to link here
-                startLoadingSpinner()
                 video_id = selectedItem.id
                 if selectedItem.selectedAudioStreamIndex <> invalid and selectedItem.selectedAudioStreamIndex > 1
                     video = CreateVideoPlayerGroup(video_id, invalid, selectedItem.selectedAudioStreamIndex)
@@ -237,12 +236,10 @@ sub Main (args as dynamic) as void
             group = CreateMovieDetailsGroup(node)
         else if isNodeEvent(msg, "seriesSelected")
             ' If you select a TV Series from ANYWHERE, follow this flow
-            startLoadingSpinner()
             node = getMsgPicker(msg, "picker")
             group = CreateSeriesDetailsGroup(node)
         else if isNodeEvent(msg, "seasonSelected")
             ' If you select a TV Season from ANYWHERE, follow this flow
-            startLoadingSpinner()
             ptr = msg.getData()
             ' ptr is for [row, col] of selected item... but we only have 1 row
             series = msg.getRoSGNode()

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -119,10 +119,8 @@ sub Main (args as dynamic) as void
             if itemNode = invalid or itemNode.id = "" then return
             if itemNode.type = "Episode" or itemNode.type = "Movie" or itemNode.type = "Video"
                 if itemNode.type = "Episode" and itemNode.selectedAudioStreamIndex <> invalid and itemNode.selectedAudioStreamIndex > 1
-                    m.global.sceneManager.callFunc("progressDialog", tr("Loading Episode Options"))
                     video = CreateVideoPlayerGroup(itemNode.id, invalid, itemNode.selectedAudioStreamIndex)
                 else
-                    m.global.sceneManager.callFunc("progressDialog", tr("Loading Video Options"))
                     video = CreateVideoPlayerGroup(itemNode.id)
                 end if
                 if video <> invalid and video.errorMsg <> "introaborted"
@@ -167,7 +165,6 @@ sub Main (args as dynamic) as void
                 group = CreateItemGrid(selectedItem)
                 sceneManager.callFunc("pushScene", group)
             else if selectedItem.type = "Episode"
-                m.global.sceneManager.callFunc("progressDialog", tr("Loading Episode Options"))
                 ' play episode
                 ' todo: create an episode page to link here
                 video_id = selectedItem.id
@@ -238,7 +235,6 @@ sub Main (args as dynamic) as void
             node = getMsgPicker(msg, "picker")
             group = CreateMovieDetailsGroup(node)
         else if isNodeEvent(msg, "seriesSelected")
-            m.global.sceneManager.callFunc("progressDialog", tr("Loading Seriers Options"))
             ' If you select a TV Series from ANYWHERE, follow this flow
             node = getMsgPicker(msg, "picker")
             group = CreateSeriesDetailsGroup(node)
@@ -320,7 +316,6 @@ sub Main (args as dynamic) as void
         else if isNodeEvent(msg, "episodeSelected")
             ' If you select a TV Episode from ANYWHERE, follow this flow
             m.selectedItemType = "Episode"
-            m.global.sceneManager.callFunc("progressDialog", tr("Loading Episode Options"))
             node = getMsgPicker(msg, "picker")
             video_id = node.id
             if node.selectedAudioStreamIndex <> invalid and node.selectedAudioStreamIndex > 1
@@ -369,7 +364,6 @@ sub Main (args as dynamic) as void
                 group = CreateVideoPlayerGroup(node.id)
                 sceneManager.callFunc("pushScene", group)
             else if node.type = "Episode"
-                m.global.sceneManager.callFunc("progressDialog", tr("Loading Episode Options"))
                 group = CreateVideoPlayerGroup(node.id)
                 sceneManager.callFunc("pushScene", group)
             else if node.type = "Audio"
@@ -387,7 +381,6 @@ sub Main (args as dynamic) as void
             btn = getButton(msg)
             group = sceneManager.callFunc("getActiveScene")
             if btn <> invalid and btn.id = "play-button"
-                m.global.sceneManager.callFunc("progressDialog", tr("Loading Movie Options"))
 
                 ' Check if a specific Audio Stream was selected
                 audio_stream_idx = 1

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -167,6 +167,7 @@ sub Main (args as dynamic) as void
             else if selectedItem.type = "Episode"
                 ' play episode
                 ' todo: create an episode page to link here
+                startLoadingSpinner()
                 video_id = selectedItem.id
                 if selectedItem.selectedAudioStreamIndex <> invalid and selectedItem.selectedAudioStreamIndex > 1
                     video = CreateVideoPlayerGroup(video_id, invalid, selectedItem.selectedAudioStreamIndex)
@@ -236,10 +237,12 @@ sub Main (args as dynamic) as void
             group = CreateMovieDetailsGroup(node)
         else if isNodeEvent(msg, "seriesSelected")
             ' If you select a TV Series from ANYWHERE, follow this flow
+            startLoadingSpinner()
             node = getMsgPicker(msg, "picker")
             group = CreateSeriesDetailsGroup(node)
         else if isNodeEvent(msg, "seasonSelected")
             ' If you select a TV Season from ANYWHERE, follow this flow
+            startLoadingSpinner()
             ptr = msg.getData()
             ' ptr is for [row, col] of selected item... but we only have 1 row
             series = msg.getRoSGNode()

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -331,6 +331,7 @@ function CreateHomeGroup()
 end function
 
 function CreateMovieDetailsGroup(movie)
+    startLoadingSpinner()
     group = CreateObject("roSGNode", "MovieDetails")
     group.overhangTitle = movie.title
     group.optionsAvailable = false
@@ -353,15 +354,17 @@ function CreateMovieDetailsGroup(movie)
     extras = group.findNode("extrasGrid")
     extras.observeField("selectedItem", m.port)
     extras.callFunc("loadParts", movie.json)
-
+    stopLoadingSpinner()
     return group
 end function
 
 function CreateSeriesDetailsGroup(series)
+    startLoadingSpinner()
     ' Get season data early in the function so we can check number of seasons.
     seasonData = TVSeasons(series.id)
     ' Divert to season details if user setting goStraightToEpisodeListing is enabled and only one season exists.
     if get_user_setting("ui.tvshows.goStraightToEpisodeListing") = "true" and seasonData.Items.Count() = 1
+        stopLoadingSpinner()
         return CreateSeasonDetailsGroupByID(series.id, seasonData.Items[0].id)
     end if
     group = CreateObject("roSGNode", "TVShowDetails")
@@ -376,7 +379,7 @@ function CreateSeriesDetailsGroup(series)
     extras = group.findNode("extrasGrid")
     extras.observeField("selectedItem", m.port)
     extras.callFunc("loadParts", group.itemcontent.json)
-
+    stopLoadingSpinner()
     return group
 end function
 
@@ -446,6 +449,7 @@ function CreateAlbumView(album)
 end function
 
 function CreateSeasonDetailsGroup(series, season)
+    startLoadingSpinner()
     group = CreateObject("roSGNode", "TVEpisodes")
     group.optionsAvailable = false
     m.global.sceneManager.callFunc("pushScene", group)
@@ -455,12 +459,14 @@ function CreateSeasonDetailsGroup(series, season)
 
     group.observeField("episodeSelected", m.port)
     group.observeField("quickPlayNode", m.port)
+
     stopLoadingSpinner()
 
     return group
 end function
 
 function CreateSeasonDetailsGroupByID(seriesID, seasonID)
+    startLoadingSpinner()
     group = CreateObject("roSGNode", "TVEpisodes")
     group.optionsAvailable = false
     m.global.sceneManager.callFunc("pushScene", group)
@@ -470,7 +476,7 @@ function CreateSeasonDetailsGroupByID(seriesID, seasonID)
 
     group.observeField("episodeSelected", m.port)
     group.observeField("quickPlayNode", m.port)
-
+    stopLoadingSpinner()
     return group
 end function
 
@@ -514,7 +520,7 @@ sub CreateSidePanel(buttons, options)
 end sub
 
 function CreateVideoPlayerGroup(video_id, mediaSourceId = invalid, audio_stream_idx = 1, forceTranscoding = false, showIntro = true, allowResumeDialog = true)
-
+    startMediaLoadingSpinner()
     ' Video is Playing
     video = VideoPlayer(video_id, mediaSourceId, audio_stream_idx, defaultSubtitleTrackFromVid(video_id), forceTranscoding, showIntro, allowResumeDialog)
 
@@ -523,17 +529,18 @@ function CreateVideoPlayerGroup(video_id, mediaSourceId = invalid, audio_stream_
     video.observeField("selectSubtitlePressed", m.port)
     video.observeField("selectPlaybackInfoPressed", m.port)
     video.observeField("state", m.port)
-
+    stopLoadingSpinner()
     return video
 end function
 
 function CreatePersonView(personData as object) as object
+    startLoadingSpinner()
     person = CreateObject("roSGNode", "PersonDetails")
     m.global.SceneManager.callFunc("pushScene", person)
 
     info = ItemMetaData(personData.id)
     person.itemContent = info
-
+    stopLoadingSpinner()
     person.setFocus(true)
     person.observeField("selectedItem", m.port)
     person.findNode("favorite-button").observeField("buttonSelected", m.port)

--- a/source/ShowScenes.brs
+++ b/source/ShowScenes.brs
@@ -455,6 +455,7 @@ function CreateSeasonDetailsGroup(series, season)
 
     group.observeField("episodeSelected", m.port)
     group.observeField("quickPlayNode", m.port)
+    stopLoadingSpinner()
 
     return group
 end function

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -6,12 +6,12 @@ function VideoPlayer(id, mediaSourceId = invalid, audio_stream_idx = 1, subtitle
     AddVideoContent(video, mediaSourceId, audio_stream_idx, subtitle_idx, -1, forceTranscoding, showIntro, allowResumeDialog)
 
     if video.errorMsg = "introaborted"
-        stopMediaLoadingSpinner()
+        stopLoadingSpinner()
         return video
     end if
 
     if video.content = invalid
-        stopMediaLoadingSpinner()
+        stopLoadingSpinner()
         return invalid
     end if
     jellyfin_blue = "#00a4dcFF"
@@ -19,7 +19,7 @@ function VideoPlayer(id, mediaSourceId = invalid, audio_stream_idx = 1, subtitle
     video.retrievingBar.filledBarBlendColor = jellyfin_blue
     video.bufferingBar.filledBarBlendColor = jellyfin_blue
     video.trickPlayBar.filledBarBlendColor = jellyfin_blue
-    stopMediaLoadingSpinner()
+    stopLoadingSpinner()
     return video
 end function
 
@@ -61,7 +61,7 @@ sub AddVideoContent(video, mediaSourceId, audio_stream_idx = 1, subtitle_idx = -
         playbackPosition = meta.json.UserData.PlaybackPositionTicks
         if allowResumeDialog
             if playbackPosition > 0
-                stopMediaLoadingSpinner()
+                stopLoadingSpinner()
                 dialogResult = startPlayBackOver(playbackPosition)
                 startMediaLoadingSpinner()
                 'Dialog returns -1 when back pressed, 0 for resume, and 1 for start over

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -2,11 +2,9 @@ function VideoPlayer(id, mediaSourceId = invalid, audio_stream_idx = 1, subtitle
     ' Get video controls and UI
     video = CreateObject("roSGNode", "JFVideo")
     video.id = id
-    startMediaLoadingSpinner()
     AddVideoContent(video, mediaSourceId, audio_stream_idx, subtitle_idx, -1, forceTranscoding, showIntro, allowResumeDialog)
 
     if video.errorMsg = "introaborted"
-        stopLoadingSpinner()
         return video
     end if
 
@@ -19,7 +17,6 @@ function VideoPlayer(id, mediaSourceId = invalid, audio_stream_idx = 1, subtitle
     video.retrievingBar.filledBarBlendColor = jellyfin_blue
     video.bufferingBar.filledBarBlendColor = jellyfin_blue
     video.trickPlayBar.filledBarBlendColor = jellyfin_blue
-    stopLoadingSpinner()
     return video
 end function
 

--- a/source/utils/misc.brs
+++ b/source/utils/misc.brs
@@ -282,17 +282,23 @@ function findNodeBySubtype(node, subtype)
     return foundNodes
 end function
 
-sub startMediaLoadingSpinner()
+sub startLoadingSpinner()
     m.spinner = createObject("roSGNode", "Spinner")
     m.spinner.translation = "[900, 450]"
+    m.spinner.visible = true
     m.scene.appendChild(m.spinner)
+end sub
+
+
+sub startMediaLoadingSpinner()
     dialog = createObject("roSGNode", "ProgressDialog")
     dialog.id = "invisibiledialog"
     dialog.visible = false
     m.scene.dialog = dialog
+    startLoadingSpinner()
 end sub
 
-sub stopMediaLoadingSpinner()
+sub stopLoadingSpinner()
     if isValid(m.spinner)
         m.spinner.visible = false
     end if

--- a/source/utils/misc.brs
+++ b/source/utils/misc.brs
@@ -281,3 +281,22 @@ function findNodeBySubtype(node, subtype)
 
     return foundNodes
 end function
+
+sub startMediaLoadingSpinner()
+    m.spinner = createObject("roSGNode", "Spinner")
+    m.spinner.translation = "[900, 450]"
+    m.scene.appendChild(m.spinner)
+    dialog = createObject("roSGNode", "ProgressDialog")
+    dialog.id = "invisibiledialog"
+    dialog.visible = false
+    m.scene.dialog = dialog
+end sub
+
+sub stopMediaLoadingSpinner()
+    if isValid(m.spinner)
+        m.spinner.visible = false
+    end if
+    if isValid(m.scene.dialog)
+        m.scene.dialog.close = true
+    end if
+end sub


### PR DESCRIPTION
changes the structure to reduce the overall amount of code.  fixes the bug you noticed from my original draft (thx)
I moved the progressdialog start/stop calls from main to showscenes where they are more reusable
startLoadingSpinner() just does the spinner with no ProgressDialog.
startMediaLoadingSpinner() calls startLoadingSpinner() on top of an invisible ProgressDialog.
stopLoadingSpinner() kills both.
