### PR TITLE
unbreak personvideos

### DIFF
--- a/components/extras/ExtrasRowList.brs
+++ b/components/extras/ExtrasRowList.brs
@@ -140,15 +140,8 @@ sub onMoviesLoaded()
     data = m.LoadMoviesTask.content
     m.LoadMoviesTask.unobserveField("content")
     if data <> invalid and data.count() > 0
-        row = m.top.content.createChild("ContentNode")
-        row.title = tr("Movies")
-        for each mov in data
-            mov.Id = mov.json.Id
-            mov.labelText = mov.json.Name
-            mov.subTitle = mov.json.ProductionYear
-            mov.Type = mov.json.Type
-            row.appendChild(mov)
-        end for
+        row = buildRow("Movies", data)
+        m.top.content.insertChild(row, 3)
         m.top.rowItemSize = [[234, 396]]
     end if
 end sub
@@ -159,7 +152,7 @@ sub onShowsLoaded()
     if data <> invalid and data.count() > 0
         row = buildRow("TV Shows", data, 502)
         addRowSize([502, 396])
-        m.top.content.appendChild(row)
+        m.top.content.insertChild(row, 2)
     end if
 end sub
 
@@ -169,7 +162,7 @@ sub onSeriesLoaded()
     if data <> invalid and data.count() > 0
         row = buildRow("Series", data)
         addRowSize([234, 396])
-        m.top.content.appendChild(row)
+        m.top.content.insertChild(row, 1)
     end if
     m.top.visible = true
 end sub

--- a/components/extras/ExtrasRowList.brs
+++ b/components/extras/ExtrasRowList.brs
@@ -54,7 +54,7 @@ sub loadParts(data as object, playback = false)
 end sub
 
 sub loadPersonVideos(personId)
-    m.rowTitlesInOrder = ["Movies", "TV Shows", "Series"]
+    m.rowTitlesInOrder = [tr("Movies"), tr("TV Shows"), tr("Series")]
     m.rowSizes = [[234, 396], [502, 396], [234, 396]]
     m.tasksToComplete = m.rowTitlesInOrder.count()
     m.personId = personId
@@ -153,7 +153,7 @@ sub onMoviesLoaded()
     data = m.LoadMoviesTask.content
     m.LoadMoviesTask.unobserveField("content")
     if data <> invalid and data.count() > 0
-        row = buildRow("Movies", data)
+        row = buildRow(tr("Movies"), data)
         m.unsortedContent.insertChild(row, 3)
     end if
     sortCompletedTasks()
@@ -164,7 +164,7 @@ sub onShowsLoaded()
     data = m.LoadShowsTask.content
     m.LoadShowsTask.unobserveField("content")
     if data <> invalid and data.count() > 0
-        row = buildRow("TV Shows", data, 502)
+        row = buildRow(tr("TV Shows"), data, 502)
         m.unsortedContent.insertChild(row, 2)
     end if
     sortCompletedTasks()
@@ -175,7 +175,7 @@ sub onSeriesLoaded()
     data = m.LoadSeriesTask.content
     m.LoadSeriesTask.unobserveField("content")
     if data <> invalid and data.count() > 0
-        row = buildRow("Series", data)
+        row = buildRow(tr("Series"), data)
         m.unsortedContent.insertChild(row, 1)
     end if
     sortCompletedTasks()

--- a/components/extras/ExtrasRowList.brs
+++ b/components/extras/ExtrasRowList.brs
@@ -3,6 +3,7 @@ sub init()
     updateSize()
     m.top.rowFocusAnimationStyle = "fixedFocus"
     m.top.observeField("rowItemSelected", "onRowItemSelected")
+    m.top.content = CreateObject("roSGNode", "ContentNode")
 
     ' Set up all Tasks
     m.LoadPeopleTask = CreateObject("roSGNode", "LoadItemsTask")
@@ -32,7 +33,6 @@ sub updateSize()
 end sub
 
 sub loadParts(data as object, playback = false)
-    m.top.content = CreateObject("roSGNode", "ContentNode") ' The row Node
     m.top.parentId = data.id
     m.people = data.People
     m.LoadPeopleTask.peopleList = m.people
@@ -44,12 +44,6 @@ sub loadParts(data as object, playback = false)
         m.LikeThisTask.control = "RUN"
         m.SpecialFeaturesTask.itemId = m.top.parentId
         m.SpecialFeaturesTask.control = "RUN"
-        m.LoadShowsTask.itemId = m.personId
-        m.LoadShowsTask.observeField("content", "onShowsLoaded")
-        m.LoadShowsTask.control = "RUN"
-        m.LoadSeriesTask.itemId = m.personId
-        m.LoadSeriesTask.observeField("content", "onSeriesLoaded")
-        m.LoadSeriesTask.control = "RUN"
     end if
 end sub
 
@@ -58,6 +52,12 @@ sub loadPersonVideos(personId)
     m.LoadMoviesTask.itemId = m.personId
     m.LoadMoviesTask.observeField("content", "onMoviesLoaded")
     m.LoadMoviesTask.control = "RUN"
+    m.LoadShowsTask.itemId = m.personId
+    m.LoadShowsTask.observeField("content", "onShowsLoaded")
+    m.LoadShowsTask.control = "RUN"
+    m.LoadSeriesTask.itemId = m.personId
+    m.LoadSeriesTask.observeField("content", "onSeriesLoaded")
+    m.LoadSeriesTask.control = "RUN"
 end sub
 
 sub onAdditionalPartsLoaded()
@@ -68,11 +68,8 @@ sub onAdditionalPartsLoaded()
         row = buildRow("Additional Parts", parts, 464)
         addRowSize([464, 291])
         m.top.content.appendChild(row)
-        print "THIS ROW SIZE"
         m.top.rowItemSize = [[464, 291]]
     end if
-    m.top.translation = "[75,10]"
-
 
 end sub
 
@@ -142,9 +139,8 @@ end function
 sub onMoviesLoaded()
     data = m.LoadMoviesTask.content
     m.LoadMoviesTask.unobserveField("content")
-    rlContent = CreateObject("roSGNode", "ContentNode")
     if data <> invalid and data.count() > 0
-        row = rlContent.createChild("ContentNode")
+        row = m.top.content.createChild("ContentNode")
         row.title = tr("Movies")
         for each mov in data
             mov.Id = mov.json.Id
@@ -155,7 +151,6 @@ sub onMoviesLoaded()
         end for
         m.top.rowItemSize = [[234, 396]]
     end if
-    m.top.content = rlContent
 end sub
 
 sub onShowsLoaded()

--- a/components/extras/ExtrasSlider.xml
+++ b/components/extras/ExtrasSlider.xml
@@ -9,7 +9,7 @@
         showRowLabel="true"
         showRowCounter="true"
         visible="true"
-        translation="[12,18]"
+        translation="[75,10]"
         itemComponentName="ExtrasItem" />
       <Animation id="pplAnime" duration=".4" repeat="false" >
         <Vector2DFieldInterpolator

--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -54,7 +54,7 @@ sub AddVideoContent(video, mediaSourceId, audio_stream_idx = 1, subtitle_idx = -
     end if
 
     video.content.title = meta.title
-    video.content.description = meta.json.CurrentProgram.Overview
+    if isValid(meta.json.CurrentProgram) then video.content.description = meta.json.CurrentProgram.Overview
     video.showID = meta.showID
 
     if playbackPosition = -1 and isValid(meta.json)


### PR DESCRIPTION
I broke personvideos when I changed the slider logic.
My changes (start all the tasks at once instead of having the task handlers call the next task in sequence) makes the load time substantially faster in my tests, ~~but it has the (obvious) side effect of putting the exrasrows in whatever order the tasks return.
this is a draft while I try to think of a solution that gives us the loading speed and the deterministic order.~~
